### PR TITLE
페이지 UI: 비밀번호 찾기 페이지

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,14 +5,14 @@ module.exports = {
   sassOptions: {
     includePaths: [path.join(__dirname, 'styles')],
   },
-  async rewrites() {
-    return [
-      {
-        source: "/:path*",
-        destination: `${process.env.NEXT_PUBLIC_BASE_URL}/:path*`,
-      },
-    ];
-  },
+  // async rewrites() {
+  //   return [
+  //     {
+  //       source: "/:path*",
+  //       destination: `${process.env.NEXT_PUBLIC_BASE_URL}/:path*`,
+  //     },
+  //   ];
+  // },
   webpack: (config, context) => {
     if (context?.isServer) {
       if (Array.isArray(config.resolve.alias)) {

--- a/src/app/find-id/page.tsx
+++ b/src/app/find-id/page.tsx
@@ -8,7 +8,7 @@ import { useForm } from 'react-hook-form';
 import dynamic from 'next/dynamic';
 
 import VALIDATION_MESSAGE_MAP from '@constants/validationMessage';
-import { IFindId } from '@remote/api/types/auth';
+import { FindId } from '@remote/api/types/auth';
 import useFindId from '@remote/queries/auth/useFindId';
 import Header from '@shared/header/Header';
 import Spacing from '@shared/spacing/Spacing';
@@ -20,12 +20,12 @@ const FixedBottomButton = dynamic(() => { return import('@shared/fixedBottomButt
 });
 
 function FindIdPage() {
-  const { register, handleSubmit, formState: { isValid, errors, isDirty } } = useForm<IFindId>({
+  const { register, handleSubmit, formState: { isValid, errors, isDirty } } = useForm<FindId>({
     mode: 'onBlur',
   });
   const { mutate } = useFindId();
 
-  const onSubmit = (data: IFindId) => {
+  const onSubmit = (data: FindId) => {
     const { email } = data;
     mutate({ email }, {
       onError: (error) => {

--- a/src/app/find-password/layout.tsx
+++ b/src/app/find-password/layout.tsx
@@ -1,0 +1,7 @@
+function FindPasswordLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ padding: '0 24px' }}>{children}</div>
+  );
+}
+
+export default FindPasswordLayout;

--- a/src/app/find-password/layout.tsx
+++ b/src/app/find-password/layout.tsx
@@ -1,7 +1,0 @@
-function FindPasswordLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <div style={{ padding: '0 24px' }}>{children}</div>
-  );
-}
-
-export default FindPasswordLayout;

--- a/src/app/find-password/page.module.scss
+++ b/src/app/find-password/page.module.scss
@@ -1,0 +1,3 @@
+.mainContainer {
+    padding: 0 24px;
+}

--- a/src/app/find-password/page.tsx
+++ b/src/app/find-password/page.tsx
@@ -9,6 +9,7 @@ import dynamic from 'next/dynamic';
 
 import VALIDATION_MESSAGE_MAP from '@constants/validationMessage';
 import { FindPassword } from '@remote/api/types/auth';
+import useFindPassword from '@remote/queries/auth/useFindPassword';
 import Header from '@shared/header/Header';
 import Spacing from '@shared/spacing/Spacing';
 import TextField from '@shared/text-field/TextField';
@@ -25,20 +26,16 @@ function FindPasswordPage() {
   } = useForm<FindPassword>({
     mode: 'onBlur',
   });
+  const { mutate, isError } = useFindPassword();
 
   const onSubmit = (data: FindPassword) => {
     const { id } = data;
-    // mutate({ id }, {
-    //   onError: (error) => {
-    //     console.error('Error:', error);
-    //     alert('아이디가 존재하지 않습니다.');
-    //     // TODO: 실패 시 알림 메세지 바로 출력
-    //   },
-    //   onSuccess: () => {
-    //     alert('사용하실 비밀번호를 입력해주세요.');
-    //     // TODO: 비밀번호 변경 페이지 로드하기
-    //   },
-    // });
+    mutate({ id }, {
+      onSuccess: () => {
+        alert('비밀번호 변경 페이지로 이동');
+        // TODO: 비밀번호 변경 페이지 로드하기
+      },
+    });
 
     console.log(id);
   };
@@ -58,6 +55,7 @@ function FindPasswordPage() {
             required: true,
             pattern: VALIDATION_MESSAGE_MAP.id.value,
           })}
+          hasError={isError}
           helpMessage={VALIDATION_MESSAGE_MAP.failedFindPassword.message}
         />
         <div>

--- a/src/app/find-password/page.tsx
+++ b/src/app/find-password/page.tsx
@@ -5,6 +5,7 @@
 
 import { useForm } from 'react-hook-form';
 
+import classNames from 'classnames/bind';
 import dynamic from 'next/dynamic';
 
 import VALIDATION_MESSAGE_MAP from '@constants/validationMessage';
@@ -14,6 +15,10 @@ import Header from '@shared/header/Header';
 import Spacing from '@shared/spacing/Spacing';
 import TextField from '@shared/text-field/TextField';
 import Title from '@shared/title/Title';
+
+import styles from './page.module.scss';
+
+const cx = classNames.bind(styles);
 
 const FixedBottomButton = dynamic(() => { return import('@shared/fixedBottomButton/FixedBottomButton'); }, {
   ssr: false,
@@ -44,7 +49,7 @@ function FindPasswordPage() {
     <>
       <Header isDisplayLogo={false} />
       <Spacing size={16} />
-      <main>
+      <main className={cx('mainContainer')}>
         <Title title="비밀번호 찾기" description="비밀번호를 찾으실 아이디를 입력해주세요." size={4} descriptionColor="tertiary" />
         <Spacing size={40} />
         <TextField

--- a/src/app/find-password/page.tsx
+++ b/src/app/find-password/page.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
+/* eslint-disable no-console */
+
+'use client';
+
+import { useForm } from 'react-hook-form';
+
+import dynamic from 'next/dynamic';
+
+import VALIDATION_MESSAGE_MAP from '@constants/validationMessage';
+import { FindPassword } from '@remote/api/types/auth';
+import Header from '@shared/header/Header';
+import Spacing from '@shared/spacing/Spacing';
+import TextField from '@shared/text-field/TextField';
+import Title from '@shared/title/Title';
+
+const FixedBottomButton = dynamic(() => { return import('@shared/fixedBottomButton/FixedBottomButton'); }, {
+  ssr: false,
+});
+
+function FindPasswordPage() {
+  const {
+    register, handleSubmit,
+    formState: { isValid, isDirty },
+  } = useForm<FindPassword>({
+    mode: 'onBlur',
+  });
+
+  const onSubmit = (data: FindPassword) => {
+    const { id } = data;
+    // mutate({ id }, {
+    //   onError: (error) => {
+    //     console.error('Error:', error);
+    //     alert('아이디가 존재하지 않습니다.');
+    //     // TODO: 실패 시 알림 메세지 바로 출력
+    //   },
+    //   onSuccess: () => {
+    //     alert('사용하실 비밀번호를 입력해주세요.');
+    //     // TODO: 비밀번호 변경 페이지 로드하기
+    //   },
+    // });
+
+    console.log(id);
+  };
+
+  return (
+    <>
+      <Header isDisplayLogo={false} />
+      <Spacing size={16} />
+      <main>
+        <Title title="비밀번호 찾기" description="비밀번호를 찾으실 아이디를 입력해주세요." size={4} descriptionColor="tertiary" />
+        <Spacing size={40} />
+        <TextField
+          label="아이디"
+          required
+          placeholder="아이디"
+          {...register('id', {
+            required: true,
+            pattern: VALIDATION_MESSAGE_MAP.id.value,
+          })}
+          helpMessage={VALIDATION_MESSAGE_MAP.failedFindPassword.message}
+        />
+        <div>
+          <FixedBottomButton
+            disabled={!isValid || !isDirty}
+            onClick={handleSubmit(onSubmit)}
+            size="medium"
+          >
+            다음
+          </FixedBottomButton>
+        </div>
+      </main>
+    </>
+  );
+}
+export default FindPasswordPage;

--- a/src/components/additional-info/car-details/CarColorPicker.tsx
+++ b/src/components/additional-info/car-details/CarColorPicker.tsx
@@ -1,14 +1,18 @@
 import { FieldValues, UseFormRegister } from 'react-hook-form';
 
 import classNames from 'classnames/bind';
+import dynamic from 'next/dynamic';
 
 import ColorPicker from '@components/additional-info/car-details/color-picker/ColorPicker';
 import Description from '@components/additional-info/description/Description';
 import { IAdditionalInfo } from '@remote/api/types/additional-info';
-import FixedBottomButton from '@shared/fixedBottomButton/FixedBottomButton';
 import Spacing from '@shared/spacing/Spacing';
 
 import styles from './CarColorPicker.module.scss';
+
+const FixedBottomButton = dynamic(() => { return import('@shared/fixedBottomButton/FixedBottomButton'); }, {
+  ssr: false,
+});
 
 const cx = classNames.bind(styles);
 

--- a/src/components/additional-info/car-details/CarDetails.tsx
+++ b/src/components/additional-info/car-details/CarDetails.tsx
@@ -1,11 +1,16 @@
 import { FieldValues, UseFormRegister } from 'react-hook-form';
 
+import dynamic from 'next/dynamic';
+
 import Description from '@components/additional-info/description/Description';
 import { IAdditionalInfo } from '@remote/api/types/additional-info';
-import FixedBottomButton from '@shared/fixedBottomButton/FixedBottomButton';
 import Flex from '@shared/flex/Flex';
 import Radio from '@shared/radio/Radio';
 import Spacing from '@shared/spacing/Spacing';
+
+const FixedBottomButton = dynamic(() => { return import('@shared/fixedBottomButton/FixedBottomButton'); }, {
+  ssr: false,
+});
 
 interface CarDetailsProps {
   onClick: () => void

--- a/src/constants/validationMessage.ts
+++ b/src/constants/validationMessage.ts
@@ -21,6 +21,7 @@ const VALIDATION_MESSAGE_MAP: {
   },
   failedLogin: { message: '아이디 또는 비밀번호를 확인해주세요.' },
   failedFindId: { message: '잘못된 이메일입니다.' },
+  failedFindPassword: { message: '아이디가 존재하지 않습니다.' },
 } as const;
 
 export default VALIDATION_MESSAGE_MAP;

--- a/src/remote/api/instance.api.ts
+++ b/src/remote/api/instance.api.ts
@@ -1,8 +1,8 @@
 import axios, { Axios } from 'axios';
 
 export const axiosInstance: Axios = axios.create({
-  // baseURL: process.env.NEXT_PUBLIC_BASE_URL,
-  baseURL: '',
+  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+  // baseURL: '',
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',

--- a/src/remote/api/requests/auth/auth.post.api.ts
+++ b/src/remote/api/requests/auth/auth.post.api.ts
@@ -1,4 +1,6 @@
-import { IFindId, ISignIn, ISignUp } from '../../types/auth';
+import {
+  FindId, FindPassword, ISignIn, ISignUp,
+} from '../../types/auth';
 import { postRequest } from '../requests.api';
 
 export const signup = async ({
@@ -23,9 +25,19 @@ export const login = async ({
 
 export const findId = async ({
   email,
-}: IFindId) => {
-  const response = await postRequest<null, IFindId>('/member/find-id', {
+}: FindId) => {
+  const response = await postRequest<null, FindId>('/member/find-id', {
     email,
+  });
+
+  return response;
+};
+
+export const findPassword = async ({
+  id,
+}: FindPassword) => {
+  const response = await postRequest<null, FindPassword>('/member/find-password', {
+    id,
   });
 
   return response;

--- a/src/remote/api/types/auth.ts
+++ b/src/remote/api/types/auth.ts
@@ -1,7 +1,3 @@
-export interface IFindId {
-  email:string
-}
-
 export interface ISignIn {
   id: string
   password: string
@@ -12,3 +8,7 @@ export interface ISignUp extends ISignIn {
   gender: string | null
   age: string | null
 }
+
+export type FindPassword = Pick<ISignIn, 'id'>;
+
+export type FindId = Pick<ISignUp, 'email'>;

--- a/src/remote/api/types/auth.ts
+++ b/src/remote/api/types/auth.ts
@@ -9,6 +9,6 @@ export interface ISignUp extends ISignIn {
   age: string | null
 }
 
-export type FindPassword = Pick<ISignIn, 'id'>;
+export type FindPassword = Pick<ISignUp, 'id'>;
 
 export type FindId = Pick<ISignUp, 'email'>;

--- a/src/remote/queries/auth/useFindPassword.ts
+++ b/src/remote/queries/auth/useFindPassword.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { findPassword } from '@remote/api/requests/auth/auth.post.api';
+
+function useFindPassword() {
+  return useMutation({ mutationFn: findPassword });
+}
+
+export default useFindPassword;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] TEST : 테스트 추가 및 리팩토링
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<img width="380" alt="image" src="https://github.com/Kernel360/F1-WashPedia-FE/assets/101791501/8b8893de-5067-4c61-b0d8-86b80b999ba5">

### How it Works
<!-- 간단한 로직 설명 -->

### To Reviewers
헤더에서 따로 좌우 24px padding값을 주고 있어서 어쩔수 없이 scss파일을 하나 만들어서 메인에 padding을 24px 주게 되었는데 이부분 글로벌에서 따로 mainContainer들은 좌우 padding값을 24px로 지정해 놓을까요?