### PR TITLE
페이지 UI: 비밀번호 변경 페이지

### DIFF
--- a/src/app/change-password/page.module.scss
+++ b/src/app/change-password/page.module.scss
@@ -1,0 +1,3 @@
+.mainContainer {
+    padding: 0 24px;
+}

--- a/src/app/change-password/page.tsx
+++ b/src/app/change-password/page.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-nested-ternary */
+/* eslint-disable no-console */
 /* eslint-disable no-alert */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 
@@ -8,6 +10,7 @@ import { useForm } from 'react-hook-form';
 import classNames from 'classnames/bind';
 import dynamic from 'next/dynamic';
 
+import useChangePassword from '@/remote/queries/auth/useChangePassword';
 import VALIDATION_MESSAGE_MAP from '@constants/validationMessage';
 import { ChangePassword } from '@remote/api/types/auth';
 import Header from '@shared/header/Header';
@@ -35,9 +38,18 @@ function ChangePasswordPage() {
     mode: 'onBlur',
   });
 
+  const { mutate, isError } = useChangePassword();
+
   const onSubmit = (data: ChangePasswordType) => {
-    // eslint-disable-next-line no-console
-    console.log(data);
+    const { password } = data;
+    mutate({ password }, {
+      onSuccess: () => {
+        alert('비밀번호 변경 완료');
+        // TODO: 비밀번호 변경 페이지 로드하기
+      },
+    });
+
+    console.log(password);
   };
 
   return (
@@ -68,8 +80,14 @@ function ChangePasswordPage() {
             required: true,
             validate: (value) => { return value === watch('password') || false; },
           })}
-          hasError={!!errors.confirmPassword}
-          helpMessage={VALIDATION_MESSAGE_MAP.confirmPassword.message}
+          hasError={!!errors.confirmPassword || isError}
+          helpMessage={
+            isError
+              ? VALIDATION_MESSAGE_MAP.failedChangePassword.message
+              : (errors.confirmPassword
+                ? VALIDATION_MESSAGE_MAP.confirmPassword.message
+                : undefined)
+          }
         />
         <div>
           <FixedBottomButton

--- a/src/app/change-password/page.tsx
+++ b/src/app/change-password/page.tsx
@@ -5,6 +5,7 @@
 
 import { useForm } from 'react-hook-form';
 
+import classNames from 'classnames/bind';
 import dynamic from 'next/dynamic';
 
 import VALIDATION_MESSAGE_MAP from '@constants/validationMessage';
@@ -13,6 +14,10 @@ import Header from '@shared/header/Header';
 import Spacing from '@shared/spacing/Spacing';
 import TextField from '@shared/text-field/TextField';
 import Title from '@shared/title/Title';
+
+import styles from './page.module.scss';
+
+const cx = classNames.bind(styles);
 
 const FixedBottomButton = dynamic(() => { return import('@shared/fixedBottomButton/FixedBottomButton'); }, {
   ssr: false,
@@ -39,7 +44,7 @@ function ChangePasswordPage() {
     <>
       <Header isDisplayLogo={false} />
       <Spacing size={16} />
-      <main>
+      <main className={cx('mainContainer')}>
         <Title title="비밀번호 변경" description="사용하실 새 비밀번호를 입력해주세요." size={4} descriptionColor="tertiary" />
         <Spacing size={40} />
         <TextField

--- a/src/app/change-password/page.tsx
+++ b/src/app/change-password/page.tsx
@@ -10,9 +10,9 @@ import { useForm } from 'react-hook-form';
 import classNames from 'classnames/bind';
 import dynamic from 'next/dynamic';
 
-import useChangePassword from '@/remote/queries/auth/useChangePassword';
 import VALIDATION_MESSAGE_MAP from '@constants/validationMessage';
 import { ChangePassword } from '@remote/api/types/auth';
+import useChangePassword from '@remote/queries/auth/useChangePassword';
 import Header from '@shared/header/Header';
 import Spacing from '@shared/spacing/Spacing';
 import TextField from '@shared/text-field/TextField';

--- a/src/app/change-password/page.tsx
+++ b/src/app/change-password/page.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable no-alert */
+/* eslint-disable @typescript-eslint/no-misused-promises */
+
+'use client';
+
+import { useForm } from 'react-hook-form';
+
+import dynamic from 'next/dynamic';
+
+import VALIDATION_MESSAGE_MAP from '@constants/validationMessage';
+import { ChangePassword } from '@remote/api/types/auth';
+import Header from '@shared/header/Header';
+import Spacing from '@shared/spacing/Spacing';
+import TextField from '@shared/text-field/TextField';
+import Title from '@shared/title/Title';
+
+const FixedBottomButton = dynamic(() => { return import('@shared/fixedBottomButton/FixedBottomButton'); }, {
+  ssr: false,
+});
+
+type ChangePasswordType = {
+  confirmPassword: string
+} & ChangePassword;
+
+function ChangePasswordPage() {
+  const {
+    register, handleSubmit, watch,
+    formState: { isValid, errors, isDirty },
+  } = useForm<ChangePasswordType>({
+    mode: 'onBlur',
+  });
+
+  const onSubmit = (data: ChangePasswordType) => {
+    // eslint-disable-next-line no-console
+    console.log(data);
+  };
+
+  return (
+    <>
+      <Header isDisplayLogo={false} />
+      <Spacing size={16} />
+      <main>
+        <Title title="비밀번호 변경" description="사용하실 새 비밀번호를 입력해주세요." size={4} descriptionColor="tertiary" />
+        <Spacing size={40} />
+        <TextField
+          label="새 비밀번호"
+          required
+          placeholder="새로운 비밀번호를 입력해주세요."
+          isPasswordType
+          {...register('password', {
+            required: true,
+            pattern: VALIDATION_MESSAGE_MAP.password.value,
+          })}
+          hasError={!!errors.password}
+          helpMessage={VALIDATION_MESSAGE_MAP.password.message}
+        />
+        <TextField
+          label="비밀번호 확인"
+          required
+          placeholder="비밀번호를 확인해주세요."
+          isPasswordType
+          {...register('confirmPassword', {
+            required: true,
+            validate: (value) => { return value === watch('password') || false; },
+          })}
+          hasError={!!errors.confirmPassword}
+          helpMessage={VALIDATION_MESSAGE_MAP.confirmPassword.message}
+        />
+        <div>
+          <FixedBottomButton
+            disabled={!isValid || !isDirty}
+            onClick={handleSubmit(onSubmit)}
+            size="medium"
+          >
+            다음
+          </FixedBottomButton>
+        </div>
+      </main>
+    </>
+  );
+}
+
+export default ChangePasswordPage;

--- a/src/app/find-id/layout.tsx
+++ b/src/app/find-id/layout.tsx
@@ -1,7 +1,0 @@
-function FindIdLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <div style={{ padding: '0 24px' }}>{children}</div>
-  );
-}
-
-export default FindIdLayout;

--- a/src/app/find-id/page.module.scss
+++ b/src/app/find-id/page.module.scss
@@ -1,0 +1,3 @@
+.mainContainer {
+    padding: 0 24px;
+}

--- a/src/app/find-id/page.tsx
+++ b/src/app/find-id/page.tsx
@@ -5,6 +5,7 @@
 
 import { useForm } from 'react-hook-form';
 
+import classNames from 'classnames/bind';
 import dynamic from 'next/dynamic';
 
 import VALIDATION_MESSAGE_MAP from '@constants/validationMessage';
@@ -15,6 +16,9 @@ import Spacing from '@shared/spacing/Spacing';
 import TextField from '@shared/text-field/TextField';
 import Title from '@shared/title/Title';
 
+import styles from './page.module.scss';
+
+const cx = classNames.bind(styles);
 const FixedBottomButton = dynamic(() => { return import('@shared/fixedBottomButton/FixedBottomButton'); }, {
   ssr: false,
 });
@@ -44,7 +48,7 @@ function FindIdPage() {
     <>
       <Header isDisplayLogo={false} />
       <Spacing size={16} />
-      <main>
+      <main className={cx('mainContainer')}>
         <Title title="아이디 찾기" description="가입할 때 입력한 이메일을 입력해주세요." size={4} descriptionColor="tertiary" />
         <Spacing size={40} />
         <TextField

--- a/src/app/find-password/page.tsx
+++ b/src/app/find-password/page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-alert */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 /* eslint-disable no-console */
 
@@ -7,6 +8,7 @@ import { useForm } from 'react-hook-form';
 
 import classNames from 'classnames/bind';
 import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
 
 import VALIDATION_MESSAGE_MAP from '@constants/validationMessage';
 import { FindPassword } from '@remote/api/types/auth';
@@ -31,14 +33,15 @@ function FindPasswordPage() {
   } = useForm<FindPassword>({
     mode: 'onBlur',
   });
+
+  const router = useRouter();
   const { mutate, isError } = useFindPassword();
 
   const onSubmit = (data: FindPassword) => {
     const { id } = data;
     mutate({ id }, {
       onSuccess: () => {
-        alert('비밀번호 변경 페이지로 이동');
-        // TODO: 비밀번호 변경 페이지 로드하기
+        router.push('/change-password');
       },
     });
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -67,7 +67,7 @@ function LoginPage() {
           <Link href="/find-id">아이디 찾기</Link>
         </li>
         <li>
-          <Link href="find-password">비밀번호 찾기</Link>
+          <Link href="/find-password">비밀번호 찾기</Link>
         </li>
       </ul>
     </main>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -61,13 +61,13 @@ function LoginPage() {
       </form>
       <ul className={cx('linkContainer')}>
         <li>
-          <Link href="/">회원가입</Link>
+          <Link href="/signup">회원가입</Link>
         </li>
         <li>
-          <Link href="/">아이디 찾기</Link>
+          <Link href="/find-id">아이디 찾기</Link>
         </li>
         <li>
-          <Link href="/">비밀번호 찾기</Link>
+          <Link href="find-password">비밀번호 찾기</Link>
         </li>
       </ul>
     </main>

--- a/src/constants/validationMessage.ts
+++ b/src/constants/validationMessage.ts
@@ -22,6 +22,7 @@ const VALIDATION_MESSAGE_MAP: {
   failedLogin: { message: '아이디 또는 비밀번호를 확인해주세요.' },
   failedFindId: { message: '잘못된 이메일입니다.' },
   failedFindPassword: { message: '아이디가 존재하지 않습니다.' },
+  failedChangePassword: { message: '비밀번호를 다시 설정해 주세요.' },
 } as const;
 
 export default VALIDATION_MESSAGE_MAP;

--- a/src/remote/api/requests/auth/auth.post.api.ts
+++ b/src/remote/api/requests/auth/auth.post.api.ts
@@ -1,7 +1,8 @@
 import {
+  ChangePassword,
   FindId, FindPassword, ISignIn, ISignUp,
 } from '../../types/auth';
-import { postRequest } from '../requests.api';
+import { postRequest, putRequest } from '../requests.api';
 
 export const signup = async ({
   id, password, email, gender, age,
@@ -38,6 +39,16 @@ export const findPassword = async ({
 }: FindPassword) => {
   const response = await postRequest<null, FindPassword>('/member/find-password', {
     id,
+  });
+
+  return response;
+};
+
+export const changePassword = async ({
+  password,
+}: ChangePassword) => {
+  const response = await putRequest<null, ChangePassword>('/member/change-password', {
+    password,
   });
 
   return response;

--- a/src/remote/api/types/auth.ts
+++ b/src/remote/api/types/auth.ts
@@ -9,6 +9,8 @@ export interface ISignUp extends ISignIn {
   age: string | null
 }
 
+export type FindId = Pick<ISignUp, 'email'>;
+
 export type FindPassword = Pick<ISignUp, 'id'>;
 
-export type FindId = Pick<ISignUp, 'email'>;
+export type ChangePassword = Pick<ISignUp, 'password'>;

--- a/src/remote/queries/auth/useChangePassword.ts
+++ b/src/remote/queries/auth/useChangePassword.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { changePassword } from '@remote/api/requests/auth/auth.post.api';
+
+function useChangePassword() {
+  return useMutation({ mutationFn: changePassword });
+}
+
+export default useChangePassword;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] TEST : 테스트 추가 및 리팩토링
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<img width="382" alt="image" src="https://github.com/Kernel360/F1-WashPedia-FE/assets/101791501/e9d356bd-c0eb-4412-880b-c6bcf621a045">

1. 비밀번호 변경 페이지 제작
2. 로그인, 비밀번호 찾기 페이지에 링크 연결
3. 추후에 완료 페이지 제작해야 함(3가지 타입 -> 회원가입 완료, 아이디 전송 완료, 비번변경 완료)

### How it Works
<!-- 간단한 로직 설명 -->

### To Reviewers
