### PR TITLE
페이지 기능: 로그인 성공시 redux에 id 저장

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-dom": "^18",
     "react-hook-form": "^7.49.2",
     "react-redux": "^9.0.4",
-    "react-slick": "^0.29.0"
+    "react-slick": "^0.29.0",
+    "redux-persist": "^6.0.0"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.6.6",

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-misused-promises */
 
 'use client';
@@ -15,6 +16,7 @@ import Header from '@shared/header/Header';
 import Spacing from '@shared/spacing/Spacing';
 import TextField from '@shared/text-field/TextField';
 import Title from '@shared/title/Title';
+import { useAppSelector } from '@stores/hooks';
 
 import styles from './page.module.scss';
 
@@ -22,7 +24,7 @@ const cx = classNames.bind(styles);
 
 function LoginPage() {
   const { register, handleSubmit, formState: { isValid } } = useForm<ISignIn>();
-  const { mutate } = useLogin();
+  const { mutate, isError, isSuccess } = useLogin();
 
   const onSubmit = (data: ISignIn) => {
     const {
@@ -33,7 +35,14 @@ function LoginPage() {
     });
   };
 
-  // TODO: api return 값에 따라 error처리
+  /* -- redux test -- */
+  const userId = useAppSelector((state) => { return state.user.id; });
+  console.log(userId);
+
+  if (isSuccess) {
+    console.log(userId);
+  }
+
   return (
     <>
       <Header />
@@ -53,6 +62,7 @@ function LoginPage() {
             placeholder="비밀번호"
             {...register('password', { required: true })}
             helpMessage={VALIDATION_MESSAGE_MAP.failedLogin.message}
+            hasError={isError}
           />
           <Spacing size={30} />
           <Button type="submit" disabled={!isValid} size="medium" full>

--- a/src/providers/StoreProvider.tsx
+++ b/src/providers/StoreProvider.tsx
@@ -3,20 +3,26 @@
 import { useRef } from 'react';
 import { Provider } from 'react-redux';
 
-import { makeStore, AppStore } from '@stores/store';
+import { PersistGate } from 'redux-persist/integration/react';
 
-function StoreProvider({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+import { makeStore, AppStore, persistor } from '@stores/store';
+
+function StoreProvider({ children }: { children: React.ReactNode }) {
   const storeRef = useRef<AppStore>();
+
   if (!storeRef.current) {
-    // Create the store instance the first time this renders
+  // Create the store instance the first time this renders
     storeRef.current = makeStore();
   }
 
-  return <Provider store={storeRef.current}>{children}</Provider>;
+  return (
+    <Provider store={storeRef.current}>
+      {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
+      <PersistGate loading={null} persistor={persistor}>
+        {children}
+      </PersistGate>
+    </Provider>
+  );
 }
 
 export default StoreProvider;

--- a/src/remote/api/requests/auth/auth.post.api.ts
+++ b/src/remote/api/requests/auth/auth.post.api.ts
@@ -1,6 +1,6 @@
 import {
   ChangePassword,
-  FindId, FindPassword, ISignIn, ISignUp,
+  FindId, FindPassword, ISignIn, ISignUp, UserInfoType,
 } from '../../types/auth';
 import { postRequest, putRequest } from '../requests.api';
 
@@ -17,7 +17,7 @@ export const signup = async ({
 export const login = async ({
   id, password,
 }: ISignIn) => {
-  const response = await postRequest<null, ISignIn>('/member/login', {
+  const response = await postRequest<UserInfoType, ISignIn>('/member/login', {
     id, password,
   });
 

--- a/src/remote/api/types/auth.ts
+++ b/src/remote/api/types/auth.ts
@@ -1,3 +1,5 @@
+import { ICommonType } from './common';
+
 export interface ISignIn {
   id: string
   password: string
@@ -5,8 +7,8 @@ export interface ISignIn {
 
 export interface ISignUp extends ISignIn {
   email: string
-  gender: string | null
-  age: string | null
+  gender: string
+  age: string
 }
 
 export type FindId = Pick<ISignUp, 'email'>;
@@ -14,3 +16,20 @@ export type FindId = Pick<ISignUp, 'email'>;
 export type FindPassword = Pick<ISignUp, 'id'>;
 
 export type ChangePassword = Pick<ISignUp, 'password'>;
+
+// 로그인 성공시 res
+export interface IUserInfo {
+  age: string
+  createdAt: string
+  createdBy: string
+  email: string
+  gender: string
+  id: string
+  jwtToken: string
+  memberNo: number
+  modifiedAt: string
+  modifiedBy: string
+  password: null
+}
+
+export type UserInfoType = ICommonType<IUserInfo>;

--- a/src/remote/api/types/auth.ts
+++ b/src/remote/api/types/auth.ts
@@ -1,4 +1,4 @@
-import { ICommonType } from './common';
+import { ICommon } from './common';
 
 export interface ISignIn {
   id: string
@@ -32,4 +32,4 @@ export interface IUserInfo {
   password: null
 }
 
-export type UserInfoType = ICommonType<IUserInfo>;
+export type UserInfoType = ICommon<IUserInfo>;

--- a/src/remote/api/types/common.ts
+++ b/src/remote/api/types/common.ts
@@ -2,12 +2,5 @@ export interface ICommon<T> {
   status: number
   code: string,
   message: string,
-  value: T[]
-}
-
-export interface ICommonType<T> {
-  status: number
-  code: string,
-  message: string,
   value: T
 }

--- a/src/remote/api/types/common.ts
+++ b/src/remote/api/types/common.ts
@@ -4,3 +4,10 @@ export interface ICommon<T> {
   message: string,
   value: T[]
 }
+
+export interface ICommonType<T> {
+  status: number
+  code: string,
+  message: string,
+  value: T
+}

--- a/src/remote/api/types/home.ts
+++ b/src/remote/api/types/home.ts
@@ -20,6 +20,6 @@ export interface IProduct {
   warningLevel: string
 }
 
-export type BannerType = ICommon<IBanner>;
-export type RecommendProductsType = ICommon<IRecommendProducts>;
+export type BannerType = ICommon<IBanner[]>;
+export type RecommendProductsType = ICommon<IRecommendProducts[]>;
 export type ProductType = ICommon<IProduct[]>;

--- a/src/remote/queries/auth/useLogin.ts
+++ b/src/remote/queries/auth/useLogin.ts
@@ -1,15 +1,23 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable no-console */
+
 import { useMutation } from '@tanstack/react-query';
 
 import { login } from '@remote/api/requests/auth/auth.post.api';
+import { useAppDispatch } from '@stores/hooks';
+import { setUserId } from '@stores/slices/userSlice';
 
 function useLogin() {
+  const dispatch = useAppDispatch();
+
   return useMutation({
     mutationFn: login,
-    // eslint-disable-next-line no-console
-    onSuccess: () => { console.log('요청 성공'); },
-    onError: () => { console.error('에러 발생'); },
-    // eslint-disable-next-line no-console
-    onSettled: () => { console.log('결과에 관계 없이 무언가 실행됨'); },
+    onSuccess: (data) => {
+      const { id, jwtToken } = data.value;
+      console.log(jwtToken); // TODO: cookie에 저장
+      dispatch(setUserId(id));
+      // TODO: 메인페이지로 이동
+    },
   });
 }
 

--- a/src/stores/slices/userSlice.ts
+++ b/src/stores/slices/userSlice.ts
@@ -1,0 +1,32 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface UserState {
+  id: string | null;
+}
+
+const initialState: UserState = {
+  id: null,
+};
+
+const userSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {
+    setUserId: (state, action: PayloadAction<string | null>) => {
+      return {
+        ...state,
+        id: action.payload,
+      };
+    },
+    clearUserId: (state) => {
+      return {
+        ...state,
+        id: null,
+      };
+    },
+  },
+});
+
+export const { setUserId, clearUserId } = userSlice.actions;
+
+export default userSlice.reducer;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1,8 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import userReducer from './slices/userSlice';
+
 export const makeStore = () => {
   return configureStore({
     reducer: {
+      user: userReducer,
     },
     middleware: (getDefaultMiddleware) => {
       return getDefaultMiddleware({

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1,19 +1,38 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import {
+  FLUSH, PAUSE, PERSIST, PURGE, REGISTER, REHYDRATE, persistReducer, persistStore,
+} from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
 
 import userReducer from './slices/userSlice';
 
-export const makeStore = () => {
-  return configureStore({
-    reducer: {
-      user: userReducer,
-    },
-    middleware: (getDefaultMiddleware) => {
-      return getDefaultMiddleware({
-        serializableCheck: false,
-      });
-    },
-  });
+const reducers = combineReducers({
+  user: userReducer,
+});
+
+const persistConfig = {
+  key: 'root',
+  storage,
+  whitelist: ['user'],
+  disableRehydrate: true,
 };
+
+const persistedReducer = persistReducer(persistConfig, reducers);
+
+export const store = configureStore({
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) => {
+    return getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+      },
+    });
+  },
+});
+
+export const makeStore = () => { return store; };
+
+export const persistor = persistStore(store);
 
 // Infer the type of makeStore
 export type AppStore = ReturnType<typeof makeStore>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9678,6 +9678,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-thunk@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-3.1.0.tgz#94aa6e04977c30e14e892eae84978c1af6058ff3"


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] TEST : 테스트 추가 및 리팩토링
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [x] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

1. 로그인 성공시 사용자 id를 저장하는 슬라이스 리듀서 생성
2. persist 사용해 새로고침 시에도 값이 유지되도록 설정
3. 로그인 성공 response 타입 정의

### How it Works
<!-- 간단한 로직 설명 -->

### To Reviewers
로그인 성공시 로직을 로그인 페이지에서 처리할지 아니면 지금처럼 쿼리훅에서 처리할지 고민인데 어떤게 더 좋을까요? 🤔