### PR TITLE
페이지 기능: 지도 페이지 마커 추가

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -8,8 +8,10 @@ import { useState } from 'react';
 
 import classNames from 'classnames/bind';
 
-import Markers from '@/components/map/markers/Markers';
+import CarWashBox from '@components/map/car-wash-box/CarWashBox';
 import KakaoMap from '@components/map/kakao-map/KakaoMap';
+import Markers from '@components/map/markers/Markers';
+import { IMarkers } from '@remote/api/types/map';
 import useMarkers from '@remote/queries/map/useMarkers';
 import BottomNav from '@shared/bottom-nav/BottomNav';
 import SearchBar from '@shared/search-bar/SearchBar';
@@ -18,6 +20,7 @@ import styles from './page.module.scss';
 
 const cx = classNames.bind(styles);
 function MapPage() {
+  const [map, setMap] = useState<any>(null);
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const { data: carWashMarkers } = useMarkers({
     minX: 36.12,
@@ -26,7 +29,7 @@ function MapPage() {
     maxY: 127.8,
     level: 2,
   });
-  const [map, setMap] = useState<any>(null);
+  const [carWash, setCarWash] = useState<IMarkers | null>(null);
 
   return (
     <div className={cx('layout')}>
@@ -34,7 +37,8 @@ function MapPage() {
         {/* <SearchBar isShadow /> */}
       </div>
       <KakaoMap map={map} setMap={setMap} />
-      <Markers map={map} carwashs={carWashMarkers!} />
+      <Markers map={map} carwashs={carWashMarkers!} setCarWash={setCarWash} />
+      <CarWashBox carWash={carWash} />
       <BottomNav />
     </div>
   );

--- a/src/components/map/car-wash-box/CarWashBox.module.scss
+++ b/src/components/map/car-wash-box/CarWashBox.module.scss
@@ -1,0 +1,13 @@
+.carWashContainer {
+  position: fixed;
+  z-index: 2;
+  right: 0;
+  bottom: calc(75.5px + 16px);
+  left: 0;
+  width: calc(100vh - 48px);
+  max-width: 300px;
+  height: 120px;
+  margin: 0 auto;
+  padding: 16px;
+  background-color: var(--white);
+}

--- a/src/components/map/car-wash-box/CarWashBox.tsx
+++ b/src/components/map/car-wash-box/CarWashBox.tsx
@@ -1,0 +1,33 @@
+import classNames from 'classnames/bind';
+
+import Flex from '@/components/shared/flex/Flex';
+import Spacing from '@/components/shared/spacing/Spacing';
+import { IMarkers } from '@/remote/api/types/map';
+import Text from '@shared/text/Text';
+
+import styles from './CarWashBox.module.scss';
+
+const cx = classNames.bind(styles);
+
+function CarWashBox({ carWash }: { carWash: IMarkers | null }) {
+  if (carWash == null) {
+    return null;
+  }
+
+  return (
+    <div className={cx('carWashContainer')}>
+      <Text typography="t5" bold display="block">{carWash.name}</Text>
+      <Spacing size={4} />
+      <Flex direction="column">
+        <Text typography="t6" bold>주소</Text>
+        <Text typography="t7" display="block">{carWash.address}</Text>
+      </Flex>
+      <Flex direction="column">
+        <Text typography="t6" bold>타입</Text>
+        <Text typography="t7" display="block">{carWash.type ?? '실내'}</Text>
+      </Flex>
+    </div>
+  );
+}
+
+export default CarWashBox;

--- a/src/components/map/kakao-map/KakaoMap.tsx
+++ b/src/components/map/kakao-map/KakaoMap.tsx
@@ -18,7 +18,7 @@ declare global {
     kakao: any
   }
 }
-const location = { lat: 37.514417066172385, lng: 127.06132898292525 };
+const LOCATION = { lat: 37.514417066172385, lng: 127.06132898292525 };
 
 interface ILocation {
   lat: number;
@@ -35,8 +35,8 @@ function KakaoMap({ map, setMap }: IKakaoProps) {
     window.kakao.maps.load(() => {
       const mapContainer = document.getElementById('map');
       const mapOption = {
-        center: new window.kakao.maps.LatLng(location.lat, location.lng),
-        level: 3,
+        center: new window.kakao.maps.LatLng(LOCATION.lat, LOCATION.lng),
+        level: 10,
       };
       const newMap = new window.kakao.maps.Map(mapContainer, mapOption);
       setMap(newMap);

--- a/src/components/map/markers/Markers.tsx
+++ b/src/components/map/markers/Markers.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-useless-fragment */
 /* eslint-disable array-callback-return */
 /* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
@@ -5,13 +6,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { useCallback, useEffect } from 'react';
+import { SetStateAction, useCallback, useEffect } from 'react';
 
-import { MarkersType } from '@remote/api/types/map';
+import { MarkersType, IMarkers } from '@remote/api/types/map';
 
 interface MarkerProps {
   map: any
   carwashs: MarkersType
+  setCarWash: React.Dispatch<SetStateAction<IMarkers | null>>
 }
 
 declare global {
@@ -20,7 +22,7 @@ declare global {
   }
 }
 
-function Markers({ map, carwashs }: MarkerProps) {
+function Markers({ map, carwashs, setCarWash }: MarkerProps) {
   const loadKakoMarkers = useCallback(() => {
     if (map) {
       // 식당 데이터 마커 띄우기
@@ -50,16 +52,20 @@ function Markers({ map, carwashs }: MarkerProps) {
 
         // 마커가 지도 위에 표시되도록 설정합니다
         marker.setMap(map);
+
+        // 선택한 가게 저장
+        window.kakao.maps.event.addListener(marker, 'click', () => {
+          setCarWash(carwash);
+        });
       });
     }
-  }, [map, carwashs]);
+  }, [map, carwashs, setCarWash]);
 
   useEffect(() => {
     loadKakoMarkers();
   }, [loadKakoMarkers, map]);
 
   return (
-    // eslint-disable-next-line react/jsx-no-useless-fragment
     <></>
   );
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] TEST : 테스트 추가 및 리팩토링
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes
![image](https://github.com/Kernel360/F1-WashPedia-FE/assets/103362820/66f14b69-ca3e-4cd8-a389-dffa59440e74)

- 지도 페이지 마커 기능 추가
- 페이지 진입 시 지도 영역이 축소 되어 보이도록 설정

### How it Works
- 추후에 목록페이지나 carousel 구현
- 맵 사이즈 변동 시 네트워크 요청이 많은 관계로 정적이 변수를 넣어놨는데 추후에는 debouncing을 걸어 네트워크 호출에 제한을 걸어둘게요

### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->